### PR TITLE
simple updated to make isempty workable for each data structures

### DIFF
--- a/src/PowerNetworkMatrix.jl
+++ b/src/PowerNetworkMatrix.jl
@@ -303,7 +303,7 @@ function Base.show_nd(
     end
 end
 
-function Base.show(io::IO, ::MIME{Symbol("text/plain")}, array::PowerNetworkMatrix)
+function Base.show(io::IO, array::PowerNetworkMatrix)
     summary(io, array)
     isempty(array) && return
     println(io, ":")

--- a/src/virtual_lodf_calculations.jl
+++ b/src/virtual_lodf_calculations.jl
@@ -54,6 +54,14 @@ struct VirtualLODF{Ax, L <: NTuple{2, Dict}} <: PowerNetworkMatrix{Float64}
     tol::Base.RefValue{Float64}
 end
 
+function Base.show(io::IO, ::MIME{Symbol("text/plain")}, array::VirtualLODF)
+    summary(io, array)
+    isempty(array) && return
+    println(io, ":")
+    Base.print_array(io, array)
+    return
+end
+
 function _get_PTDF_A_diag(
     K::KLU.KLUFactorization{Float64, Int},
     BA::SparseArrays.SparseMatrixCSC{Float64, Int},

--- a/src/virtual_ptdf_calculations.jl
+++ b/src/virtual_ptdf_calculations.jl
@@ -57,6 +57,14 @@ struct VirtualPTDF{Ax, L <: NTuple{2, Dict}} <: PowerNetworkMatrix{Float64}
     tol::Base.RefValue{Float64}
 end
 
+function Base.show(io::IO, ::MIME{Symbol("text/plain")}, array::VirtualPTDF)
+    summary(io, array)
+    isempty(array) && return
+    println(io, ":")
+    Base.print_array(io, array)
+    return
+end
+
 """
 Builds the PTDF matrix from a group of branches and buses. The return is a
 PTDF array indexed with the branch numbers.

--- a/test/test_BA_ABA_matrix.jl
+++ b/test/test_BA_ABA_matrix.jl
@@ -90,7 +90,7 @@ end
     for mat in [a, ba, aba]
         test_value = false
         try
-            show(@eval a);
+            show(@eval a)
             test_value = true
         catch err
             if err isa Exception
@@ -99,5 +99,4 @@ end
         end
         @test test_value
     end
-
 end

--- a/test/test_BA_ABA_matrix.jl
+++ b/test/test_BA_ABA_matrix.jl
@@ -79,3 +79,25 @@ end
     end
     @test test_val
 end
+
+@testset "Test show for A, BA and ABA matrix" begin
+    sys = PSB.build_system(PSB.PSITestSystems, "c_sys5")
+
+    a = IncidenceMatrix(sys)
+    ba = BA_Matrix(sys)
+    aba = ABA_Matrix(sys)
+
+    for mat in [a, ba, aba]
+        test_value = false
+        try
+            show(@eval a);
+            test_value = true
+        catch err
+            if err isa Exception
+                test_value = false
+            end
+        end
+        @test test_value
+    end
+
+end

--- a/test/test_virtual_lodf.jl
+++ b/test/test_virtual_lodf.jl
@@ -125,7 +125,7 @@ end
     # test show
     test_value = false
     try
-        show(vlodf);
+        show(vlodf)
         test_value = true
     catch err
         if err isa Exception
@@ -133,5 +133,4 @@ end
         end
     end
     @test test_value
-
 end

--- a/test/test_virtual_lodf.jl
+++ b/test/test_virtual_lodf.jl
@@ -103,9 +103,11 @@ end
 @testset "Test Virtual LODF auxiliary functions" begin
     sys = PSB.build_system(PSB.PSITestSystems, "c_sys5")
 
+    # test isempty when VirtualLODF is created (cache must be empty)
     vlodf = VirtualLODF(sys)
     @test isempty(vlodf) == true
 
+    # test eachindex and axes
     @test length(eachindex(vlodf)) ==
           length(axes(vlodf)[1]) * length(axes(vlodf)[2])
 
@@ -119,4 +121,17 @@ end
         end
     end
     @test test_value
+
+    # test show
+    test_value = false
+    try
+        show(vlodf);
+        test_value = true
+    catch err
+        if err isa Exception
+            test_value = false
+        end
+    end
+    @test test_value
+
 end

--- a/test/test_virtual_ptdf.jl
+++ b/test/test_virtual_ptdf.jl
@@ -181,7 +181,7 @@ end
     # test show
     test_value = false
     try
-        show(vptdf);
+        show(vptdf)
         test_value = true
     catch err
         if err isa Exception
@@ -189,5 +189,4 @@ end
         end
     end
     @test test_value
-
 end

--- a/test/test_virtual_ptdf.jl
+++ b/test/test_virtual_ptdf.jl
@@ -177,4 +177,17 @@ end
     @test setdiff(PNM.get_branch_ax(vptdf), PSY.get_name.(PNM.get_ac_branches(sys))) ==
           String[]
     @test setdiff(PNM.get_bus_ax(vptdf), PSY.get_number.(PNM.get_buses(sys))) == String[]
+
+    # test show
+    test_value = false
+    try
+        show(vptdf);
+        test_value = true
+    catch err
+        if err isa Exception
+            test_value = false
+        end
+    end
+    @test test_value
+
 end


### PR DESCRIPTION
Without theses changes, PowerFlows.jl was throwing an error related to `Base.show`. The following changes fix the issue.
