### PR TITLE
Fix issue #102

### DIFF
--- a/test/test_BA_ABA_matrix.jl
+++ b/test/test_BA_ABA_matrix.jl
@@ -1,44 +1,44 @@
 @testset "Test A, BA, and ABA matrix creation" begin
     # test on 5 and 14 bus system
-    for name in ["c_sys5", "c_sys14"]
-        sys = PSB.build_system(PSB.PSITestSystems, name)
-        # at first let's see if factorization flag works
-        ABA_no_lu = ABA_Matrix(sys)
-        @test isnothing(ABA_no_lu.K)
-        # check the is_factorized function
-        @test is_factorized(ABA_no_lu) == false
-        # factorize the ABA matrix
-        ABA_no_lu = factorize(ABA_no_lu)
-        @test is_factorized(ABA_no_lu) == true
-        # get the ABA matrix with the current method
-        ABA_lu = ABA_Matrix(sys; factorize = true)
-        # check the is_factorized function
-        @test is_factorized(ABA_no_lu) == true
-        # evaluate if the ABA matrix is correct
-        A = IncidenceMatrix(sys)
-        BA = BA_Matrix(sys)
-        ABA_2 = transpose(A.data) * BA.data'
-        @test isapprox(
-            ABA_lu.data,
-            ABA_2[setdiff(1:end, A.ref_bus_positions), setdiff(1:end, A.ref_bus_positions)],
-            atol = 1e-8,
-        )
+    #for name in ["c_sys5", "c_sys14"]
+    sys = PSB.build_system(PSB.PSISystems, "RTS_GMLC_DA_sys")
+    # at first let's see if factorization flag works
+    ABA_no_lu = ABA_Matrix(sys)
+    @test isnothing(ABA_no_lu.K)
+    # check the is_factorized function
+    @test is_factorized(ABA_no_lu) == false
+    # factorize the ABA matrix
+    ABA_no_lu = factorize(ABA_no_lu)
+    @test is_factorized(ABA_no_lu) == true
+    # get the ABA matrix with the current method
+    ABA_lu = ABA_Matrix(sys; factorize = true)
+    # check the is_factorized function
+    @test is_factorized(ABA_no_lu) == true
+    # evaluate if the ABA matrix is correct
+    A = IncidenceMatrix(sys)
+    BA = BA_Matrix(sys)
+    ABA_2 = transpose(A.data) * BA.data'
+    @test isapprox(
+        ABA_lu.data,
+        ABA_2[setdiff(1:end, A.ref_bus_positions), setdiff(1:end, A.ref_bus_positions)],
+        atol = 1e-8,
+    )
 
-        # evaluate if the LU factorization evaluates a correct PTDF matrix
-        ptdf_1 = PTDF(sys)
-        Ix = Matrix(1.0I, size(ABA_lu.data, 1), size(ABA_lu.data, 1))
-        ABA_inv = ABA_lu.K \ Ix
-        ptdf_2 = BA.data[setdiff(1:end, A.ref_bus_positions), :]' * ABA_inv
-        @test isapprox(
-            ptdf_1.data[setdiff(1:end, A.ref_bus_positions), :],
-            ptdf_2',
-            atol = 1e-8,
-        )
-    end
+    # evaluate if the LU factorization evaluates a correct PTDF matrix
+    ptdf_1 = PTDF(sys)
+    Ix = Matrix(1.0I, size(ABA_lu.data, 1), size(ABA_lu.data, 1))
+    ABA_inv = ABA_lu.K \ Ix
+    ptdf_2 = BA.data[setdiff(1:end, A.ref_bus_positions), :]' * ABA_inv
+    @test isapprox(
+        ptdf_1.data[setdiff(1:end, A.ref_bus_positions), :],
+        ptdf_2',
+        atol = 1e-8,
+    )
+    #end
 end
 
 @testset "Test BA and ABA matrix indexing" begin
-    sys = PSB.build_system(PSB.PSITestSystems, "c_sys5")
+    sys = PSB.build_system(PSB.PSISystems, "RTS_GMLC_DA_sys")
 
     # get the matrices
     ba = BA_Matrix(sys)
@@ -66,7 +66,8 @@ end
     end
 
     # test if error is correctly thrown when ref bus is called
-    rb = collect(ba.ref_bus_positions)[1]
+    buses = get_components(PSY.ACBus, sys)
+    rb = [bus for bus in buses if get_bustype(bus) == PSY.ACBusTypes.REF][1]
     @test_throws ErrorException aba[rb, :]
 end
 

--- a/test/test_BA_ABA_matrix.jl
+++ b/test/test_BA_ABA_matrix.jl
@@ -1,40 +1,44 @@
 @testset "Test A, BA, and ABA matrix creation" begin
-    # test on 5 and 14 bus system
-    #for name in ["c_sys5", "c_sys14"]
-    sys = PSB.build_system(PSB.PSISystems, "RTS_GMLC_DA_sys")
-    # at first let's see if factorization flag works
-    ABA_no_lu = ABA_Matrix(sys)
-    @test isnothing(ABA_no_lu.K)
-    # check the is_factorized function
-    @test is_factorized(ABA_no_lu) == false
-    # factorize the ABA matrix
-    ABA_no_lu = factorize(ABA_no_lu)
-    @test is_factorized(ABA_no_lu) == true
-    # get the ABA matrix with the current method
-    ABA_lu = ABA_Matrix(sys; factorize = true)
-    # check the is_factorized function
-    @test is_factorized(ABA_no_lu) == true
-    # evaluate if the ABA matrix is correct
-    A = IncidenceMatrix(sys)
-    BA = BA_Matrix(sys)
-    ABA_2 = transpose(A.data) * BA.data'
-    @test isapprox(
-        ABA_lu.data,
-        ABA_2[setdiff(1:end, A.ref_bus_positions), setdiff(1:end, A.ref_bus_positions)],
-        atol = 1e-8,
-    )
+    # test on 5 and 14 bus system, and RTS.
+    for (category, name) in [
+        (PSITestSystems, "c_sys5"),
+        (PSITestSystems, "c_sys14"),
+        (PSISystems, "RTS_GMLC_DA_sys"),
+    ]
+        sys = PSB.build_system(category, name)
+        # at first let's see if factorization flag works
+        ABA_no_lu = ABA_Matrix(sys)
+        @test isnothing(ABA_no_lu.K)
+        # check the is_factorized function
+        @test is_factorized(ABA_no_lu) == false
+        # factorize the ABA matrix
+        ABA_no_lu = factorize(ABA_no_lu)
+        @test is_factorized(ABA_no_lu) == true
+        # get the ABA matrix with the current method
+        ABA_lu = ABA_Matrix(sys; factorize = true)
+        # check the is_factorized function
+        @test is_factorized(ABA_no_lu) == true
+        # evaluate if the ABA matrix is correct
+        A = IncidenceMatrix(sys)
+        BA = BA_Matrix(sys)
+        ABA_2 = transpose(A.data) * BA.data'
+        @test isapprox(
+            ABA_lu.data,
+            ABA_2[setdiff(1:end, A.ref_bus_positions), setdiff(1:end, A.ref_bus_positions)],
+            atol = 1e-8,
+        )
 
-    # evaluate if the LU factorization evaluates a correct PTDF matrix
-    ptdf_1 = PTDF(sys)
-    Ix = Matrix(1.0I, size(ABA_lu.data, 1), size(ABA_lu.data, 1))
-    ABA_inv = ABA_lu.K \ Ix
-    ptdf_2 = BA.data[setdiff(1:end, A.ref_bus_positions), :]' * ABA_inv
-    @test isapprox(
-        ptdf_1.data[setdiff(1:end, A.ref_bus_positions), :],
-        ptdf_2',
-        atol = 1e-8,
-    )
-    #end
+        # evaluate if the LU factorization evaluates a correct PTDF matrix
+        ptdf_1 = PTDF(sys)
+        Ix = Matrix(1.0I, size(ABA_lu.data, 1), size(ABA_lu.data, 1))
+        ABA_inv = ABA_lu.K \ Ix
+        ptdf_2 = BA.data[setdiff(1:end, A.ref_bus_positions), :]' * ABA_inv
+        @test isapprox(
+            ptdf_1.data[setdiff(1:end, A.ref_bus_positions), :],
+            ptdf_2',
+            atol = 1e-8,
+        )
+    end
 end
 
 @testset "Test BA and ABA matrix indexing" begin


### PR DESCRIPTION
I added a `ref_bus_numbers::Set{Int}` field to `ABA_Matrix`, and replaced `ref_bus_positions` with `ref_bus_numbers` in the spots mentioned in issue #102. I also changed the system in the test case to`RTS_GMLC_DA_sys`, one where the bus numbers aren't consecutive integers. (Lines 3-37 in `test_BA_ABA_matrix.jl` could be reverted.)