### PR TITLE
bugfix virtual ptdf subnetworks

### DIFF
--- a/src/virtual_ptdf_calculations.jl
+++ b/src/virtual_ptdf_calculations.jl
@@ -116,10 +116,10 @@ function VirtualPTDF(
     BA = calculate_BA_matrix(branches, bus_ax_ref, network_reduction)
     ABA = calculate_ABA_matrix(A, BA, ref_bus_positions)
     ref_bus_positions = find_slack_positions(buses)
-    subnetworks = find_subnetworks(M, bus_ax)
+    subnetworks =
+        assign_reference_buses!(find_subnetworks(M, bus_ax), ref_bus_positions, bus_ax_ref)
     if length(subnetworks) > 1
         @info "Network is not connected, using subnetworks"
-        subnetworks = assign_reference_buses!(subnetworks, ref_bus_positions, bus_ax_ref)
     end
     temp_data = zeros(length(bus_ax))
 


### PR DESCRIPTION
VirtualPTDF did not assign reference bus as key to subnetwork buses in case of a single subnetwork. PTDF was assigning reference bus as key always. PSI uses keys of subnetworks for reference bus detection. This PR fixes the error with assigning the reference bus in the internal PSI model when using VirtualPTDF.