### PR TITLE
sizehint in union-find code

### DIFF
--- a/src/connectivity_checks.jl
+++ b/src/connectivity_checks.jl
@@ -149,10 +149,15 @@ function find_subnetworks(M::SparseArrays.SparseMatrixCSC, bus_numbers::Vector{I
         uf[i] = get_representative(uf, i)
     end
     # now we have the representatives, so assemble the subnetworks.
+    num_subnetworks = length(unique(uf))
+    avg_size = div(size(bus_numbers, 1), num_subnetworks)
     subnetworks = Dict{Int, Set{Int}}()
     for (representative, bus_num) in zip(uf, bus_numbers)
-        subnetwork = get!(subnetworks, bus_numbers[representative], Set{Int}())
-        push!(subnetwork, bus_num)
+        if !haskey(subnetworks, bus_numbers[representative])
+            subnetworks[bus_numbers[representative]] = Set{Int}()
+            sizehint!(subnetworks[bus_numbers[representative]], avg_size)
+        end
+        push!(subnetworks[bus_numbers[representative]], bus_num)
     end
     return subnetworks
 end


### PR DESCRIPTION
Add a `sizehint!` when for in the union-find algorithm. Performance comparison below. Note the GC percent and memory usage: most systems we're dealing with in practice are connected, in which case this `sizehint!` guess is spot-on and we don't need to allocate again after that.

edit: system used for comparison is `Base_Eastern_Interconnect_515GW.RAW`. Code I'm using:
```julia
ybus = PNM.Ybus(sys; check_connectivity = false)
bus_ax = axes(ybus, 2)
@benchmark islands1 = PNM.find_subnetworks(ybus.data, bus_ax)
```

<img width="938" height="610" alt="union-find-comparison" src="https://github.com/user-attachments/assets/a940c905-1eb6-4930-a4c6-c5d53691bd78" />

