### PR TITLE
change display for matrices that store transpose

### DIFF
--- a/src/BA_ABA_matrices.jl
+++ b/src/BA_ABA_matrices.jl
@@ -36,7 +36,7 @@ get_bus_axis(M::BA_Matrix) = M.axes[1]
 get_bus_lookup(M::BA_Matrix) = M.lookup[1]
 get_arc_axis(M::BA_Matrix) = M.axes[2]
 get_arc_lookup(M::BA_Matrix) = M.lookup[2]
-stores_transpose(::BA_Matrix) = true 
+stores_transpose(::BA_Matrix) = true
 
 function BA_Matrix(sys::PSY.System;
     network_reductions::Vector{NetworkReduction} = Vector{NetworkReduction}(),

--- a/src/PowerNetworkMatrix.jl
+++ b/src/PowerNetworkMatrix.jl
@@ -38,7 +38,7 @@ function make_ax_ref(ax::AbstractVector)
     end
     return ref
 end
-stores_transpose(::PowerNetworkMatrix) = false 
+stores_transpose(::PowerNetworkMatrix) = false
 
 # AbstractArray interface: overloading methods
 Base.isempty(A::PowerNetworkMatrix) = isempty(A.data)
@@ -207,15 +207,16 @@ function Base.summary(io::IO, A::PowerNetworkMatrix)
     _summary(io, A)
     if stores_transpose(A)
         axes = (A.axes[2], A.axes[1])
-    else 
+    else
         axes = A.axes
-    end 
+    end
     for (k, ax) in enumerate(axes)
         print(io, "    Dimension $k, ")
         show(IOContext(io, :limit => true), ax)
         println(io)
     end
-    stores_transpose(A) && println(io, "Note!! The data shown below corresponds to the transposed matrix.")
+    stores_transpose(A) &&
+        println(io, "Note!! The data shown below corresponds to the transposed matrix.")
     print(io, "And data with size ", size(A))
     return
 end

--- a/src/lodf_calculations.jl
+++ b/src/lodf_calculations.jl
@@ -26,7 +26,7 @@ struct LODF{Ax, L <: NTuple{2, Dict}, M <: AbstractArray{Float64, 2}} <:
     tol::Base.RefValue{Float64}
     network_reduction_data::NetworkReductionData
 end
-stores_transpose(::LODF) = true 
+stores_transpose(::LODF) = true
 
 function _buildlodf(
     a::SparseArrays.SparseMatrixCSC{Int8, Int},

--- a/src/ptdf_calculations.jl
+++ b/src/ptdf_calculations.jl
@@ -44,7 +44,7 @@ get_bus_lookup(M::PTDF) = M.lookup[1]
 get_arc_axis(M::PTDF) = M.axes[2]
 get_arc_lookup(M::PTDF) = M.lookup[2]
 
-stores_transpose(::PTDF) = true 
+stores_transpose(::PTDF) = true
 
 """
 Deserialize a PTDF from an HDF5 file.


### PR DESCRIPTION
Addresses these issues related to confusion over indexing into the matrices that store the transpose:
https://github.com/NREL-Sienna/PowerNetworkMatrices.jl/issues/137
https://github.com/NREL-Sienna/PowerNetworkMatrices.jl/issues/153

- Changes the order that the axes are printed for the `PTDF`, `LODF`, `BA_Matrix` so that the correct order for using the custom indexing is `matrix[dim1, dim2]` and is more intuitive. 

- Includes a note for these matrices that the data that is shown is actually the transposed matrix.