### PR TITLE
add helpers for parallel branches

### DIFF
--- a/src/Ybus.jl
+++ b/src/Ybus.jl
@@ -372,6 +372,20 @@ function ybus_branch_entries(br::PSY.ACTransmission)
     return (Y11, Y12, Y21, Y22)
 end
 
+function ybus_branch_entries(parallel_br::Set{PSY.ACTransmission})
+    arc = get_arc_tuple(first(parallel_br))
+    Y11 = Y12 = Y21 = Y22 = zero(ComplexF32)
+    for br in parallel_br
+        @assert get_arc_tuple(br) == arc
+        (y11, y12, y21, y22) = ybus_branch_entries(br)
+        Y11 += y11
+        Y12 += y12
+        Y21 += y21
+        Y22 += y22
+    end
+    return (Y11, Y12, Y21, Y22)
+end
+
 _get_tap(::PSY.Transformer2W) = one(ComplexF32)
 _get_tap(br::PSY.TwoWindingTransformer) = PSY.get_tap(br)
 

--- a/src/common.jl
+++ b/src/common.jl
@@ -93,6 +93,10 @@ function get_arc_tuple(br::Set{PSY.ACTransmission}, nr::NetworkReductionData)
     get_arc_tuple(PSY.get_arc(first(br)), nr)
 end
 
+function get_arc_tuple(br::Set{PSY.ACTransmission})
+    return get_arc_tuple(PSY.get_arc(first(br)))
+end
+
 function get_arc_tuple(br::PSY.ACTransmission)
     return get_arc_tuple(PSY.get_arc(br))
 end


### PR DESCRIPTION
In the network reduction, parallel branches are represented by a `Set{PSY.ACTransmission}`, 3WT arcs by `Tuple{PSY.ThreeWindingTransformer, Int}`, and normal lines by `PSY.ACTransmission`. Fill in some missing functions for the first, so that we have a more uniform interface and things stay clean in PF.