### PR TITLE
name change: get_series_susceptances

### DIFF
--- a/src/BA_ABA_matrices.jl
+++ b/src/BA_ABA_matrices.jl
@@ -150,7 +150,7 @@ function _get_series_susceptance(segment::Set{PSY.ACTransmission})
 end
 function _get_series_susceptance(segment::Tuple{PSY.ThreeWindingTransformer, Int})
     tfw, winding_int = segment
-    return PSY.get_series_susceptance(tfw)[winding_int]
+    return PSY.get_series_susceptances(tfw)[winding_int]
 end
 
 """


### PR DESCRIPTION
Update for the method name change in:

- https://github.com/NREL-Sienna/PowerSystems.jl/pull/1523

This method is tested with the addition of: 

- https://github.com/NREL-Sienna/PowerNetworkMatrices.jl/pull/184
