### PR TITLE
remove assertion on parallel arc

### DIFF
--- a/src/Ybus.jl
+++ b/src/Ybus.jl
@@ -398,6 +398,7 @@ function ybus_branch_entries(parallel_br::BranchesParallel)
     arc = get_arc_tuple(first(parallel_br))
     Y11 = Y12 = Y21 = Y22 = zero(ComplexF32)
     for br in parallel_br
+        # All branches in BranchesParallel are have the same orientation when constructed in add_to_branch_maps!
         (y11, y12, y21, y22) = ybus_branch_entries(br)
         Y11 += y11
         Y12 += y12


### PR DESCRIPTION
I think we can safely remove this assertion which is causing test failures in PowerFlows. We only add a branch to a `BranchesParallel` object if the arc matches exactly the entry in an existing map
here: https://github.com/NREL-Sienna/PowerNetworkMatrices.jl/blob/2289299c470a59f2dc5f8b779257945fc1476e98/src/Ybus.jl#L209 and here:
https://github.com/NREL-Sienna/PowerNetworkMatrices.jl/blob/2289299c470a59f2dc5f8b779257945fc1476e98/src/Ybus.jl#L212
This means all branches in `BranchesParallel` should have the same orientation already.
This assertion was failing not because of swapped orientation, but because of a breaker/switch reduction which remaps one of the terminating buses.

 Consider a line from bus 1 to bus 2 and a line from bus 1 to bus 3. If bus 2 and 3 have a closed switch between them, bus 3 is effectively remapped to bus 2. These lines can be combined into a single `BranchesParallel` object because they are both keyed by `(1,2)` in the network reduction maps. However this assertion as written will fail because `(1,2) != (1,3)`