### PR TITLE
overload get_arc for 3wt winding

### DIFF
--- a/src/PowerNetworkMatrices.jl
+++ b/src/PowerNetworkMatrices.jl
@@ -34,7 +34,7 @@ export ArcAdmittanceMatrix
 using DocStringExtensions
 import InfrastructureSystems
 import PowerSystems
-import PowerSystems: ACBusTypes
+import PowerSystems: ACBusTypes, get_arc
 
 const IS = InfrastructureSystems
 const PSY = PowerSystems

--- a/src/ThreeWindingTransformerWinding.jl
+++ b/src/ThreeWindingTransformerWinding.jl
@@ -84,27 +84,24 @@ function get_equivalent_available(tw::ThreeWindingTransformerWinding)
     return winding_status
 end
 
-function get_arc_tuple(tr::ThreeWindingTransformerWinding)
+function PSY.get_arc(tr::ThreeWindingTransformerWinding)
     t3W = get_transformer(tr)
     arc_number = get_winding_number(tr)
     if arc_number == 1
-        return (
-            PSY.get_number(PSY.get_from(PSY.get_primary_star_arc(t3W))),
-            PSY.get_number(PSY.get_to(PSY.get_primary_star_arc(t3W))),
-        )
+        return PSY.get_primary_star_arc(t3W)
     elseif arc_number == 2
-        return (
-            PSY.get_number(PSY.get_from(PSY.get_secondary_star_arc(t3W))),
-            PSY.get_number(PSY.get_to(PSY.get_secondary_star_arc(t3W))),
-        )
+        return PSY.get_secondary_star_arc(t3W)
     elseif arc_number == 3
-        return (
-            PSY.get_number(PSY.get_from(PSY.get_tertiary_star_arc(t3W))),
-            PSY.get_number(PSY.get_to(PSY.get_tertiary_star_arc(t3W))),
-        )
+        return PSY.get_tertiary_star_arc(t3W)
+
     else
         throw(error("Three-winding transformer arc number must be 1, 2, or 3"))
     end
+end
+
+function get_arc_tuple(tr::ThreeWindingTransformerWinding)
+    arc = PSY.get_arc(tr)
+    return (PSY.get_number(PSY.get_from(arc)), PSY.get_number(PSY.get_to(arc)))
 end
 
 function add_to_map(device::ThreeWindingTransformerWinding, filters::Dict)


### PR DESCRIPTION
Define `get_arc` for `ThreeWindingTransformerWinding`. This is hit in PSI when building the area interchanges
