### PR TITLE
define matrix types for use in power flows

### DIFF
--- a/src/PowerNetworkMatrices.jl
+++ b/src/PowerNetworkMatrices.jl
@@ -30,6 +30,12 @@ export VirtualLODF
 export VirtualPTDF
 export Ybus
 export ArcAdmittanceMatrix
+export DC_ABA_Matrix_Factorized
+export DC_ABA_Matrix_Unfactorized
+export DC_PTDF_Matrix
+export DC_vPTDF_Matrix
+export DC_BA_Matrix
+export AC_Ybus_Matrix
 
 using DocStringExtensions
 import InfrastructureSystems
@@ -95,6 +101,7 @@ include("BA_ABA_matrices.jl")
 include("ptdf_calculations.jl")
 include("row_cache.jl")
 include("virtual_ptdf_calculations.jl")
+include("PowerflowMatrixTypes.jl")
 include("lodf_calculations.jl")
 include("virtual_lodf_calculations.jl")
 include("system_utils.jl")

--- a/src/PowerflowMatrixTypes.jl
+++ b/src/PowerflowMatrixTypes.jl
@@ -1,0 +1,40 @@
+const DC_ABA_Matrix_Factorized = ABA_Matrix{
+    Tuple{Vector{Int64}, Vector{Int64}},
+    Tuple{Dict{Int64, Int64}, Dict{Int64, Int64}},
+    KLU.KLUFactorization{Float64, Int64},
+}
+const DC_ABA_Matrix_Unfactorized = ABA_Matrix{
+    Tuple{Vector{Int64}, Vector{Int64}},
+    Tuple{Dict{Int64, Int64}, Dict{Int64, Int64}},
+    Nothing,
+}
+# TODO: what about MKLPardiso? switch to <:LinearAlgebra.Factorization instead?
+@static if USE_AA
+    const DC_vPTDF_Matrix = VirtualPTDF{
+        Tuple{Vector{Tuple{Int, Int}}, Vector{Int64}},
+        Tuple{Dict{Tuple{Int, Int}, Int64}, Dict{Int64, Int64}},
+        <:Union{
+            AppleAccelerate.AAFactorization{Float64},
+            KLU.KLUFactorization{Float64, Int64},
+        },
+    }
+else
+    const DC_vPTDF_Matrix = VirtualPTDF{
+        Tuple{Vector{Tuple{Int, Int}}, Vector{Int64}},
+        Tuple{Dict{Tuple{Int, Int}, Int64}, Dict{Int64, Int64}},
+        KLU.KLUFactorization{Float64, Int64},
+    }
+end
+const DC_PTDF_Matrix = PTDF{
+    Tuple{Vector{Int64}, Vector{Tuple{Int, Int}}},
+    Tuple{Dict{Int64, Int64}, Dict{Tuple{Int, Int}, Int64}},
+    Matrix{Float64},
+}
+const DC_BA_Matrix = BA_Matrix{
+    Tuple{Vector{Int64}, Vector{Tuple{Int, Int}}},
+    Tuple{Dict{Int64, Int64}, Dict{Tuple{Int, Int}, Int64}},
+}
+const AC_Ybus_Matrix = Ybus{
+    Tuple{Vector{Int64}, Vector{Int64}},
+    Tuple{Dict{Int64, Int64}, Dict{Int64, Int64}},
+}

--- a/test/test_powerflow_matrix_types.jl
+++ b/test/test_powerflow_matrix_types.jl
@@ -1,0 +1,41 @@
+@testset "Test powerflow matrix types" begin
+    sys = PSB.build_system(PSB.PSITestSystems, "c_sys5")
+
+    @testset "DC_ABA_Matrix_Factorized" begin
+        if PNM.USE_AA
+            M = ABA_Matrix(sys; factorize = true)
+            @test M isa PNM.DC_ABA_Matrix_Factorized
+        end
+    end
+
+    @testset "DC_ABA_Matrix_Unfactorized" begin
+        M = ABA_Matrix(sys; factorize = false)
+        @test M isa PNM.DC_ABA_Matrix_Unfactorized
+    end
+
+    @testset "DC_PTDF_Matrix" begin
+        if PNM.USE_AA
+            @test PTDF(sys; linear_solver = "AppleAccelerate") isa PNM.DC_PTDF_Matrix
+        end
+        @test PTDF(sys; linear_solver = "KLU") isa PNM.DC_PTDF_Matrix
+        @test PTDF(sys; linear_solver = "Dense") isa PNM.DC_PTDF_Matrix
+    end
+
+    @testset "DC_vPTDF_Matrix" begin
+        if PNM.USE_AA
+            @test VirtualPTDF(sys; linear_solver = "AppleAccelerate") isa
+                  PNM.DC_vPTDF_Matrix
+        end
+        @test VirtualPTDF(sys; linear_solver = "KLU") isa PNM.DC_vPTDF_Matrix
+    end
+
+    @testset "DC_BA_Matrix" begin
+        M = BA_Matrix(sys)
+        @test M isa PNM.DC_BA_Matrix
+    end
+
+    @testset "AC_Ybus_Matrix" begin
+        M = Ybus(sys)
+        @test M isa PNM.AC_Ybus_Matrix
+    end
+end


### PR DESCRIPTION
Currently, in PF, we have definitions like
```julia
const PTDFPowerFlowData = PowerFlowData{
    PNM.PTDF{
        Tuple{Vector{Int64}, Vector{Tuple{Int, Int}}},
        Tuple{Dict{Int64, Int64}, Dict{Tuple{Int, Int}, Int64}},
        Matrix{Float64},
    },
    PNM.ABA_Matrix{
        Tuple{Vector{Int64}, Vector{Int64}},
        Tuple{Dict{Int64, Int64}, Dict{Int64, Int64}},
        PNM.KLU.KLUFactorization{Float64, Int64},
    },
}
```
As a result, changes to the type parameters in PNM cause things to break in PF. If we define the inner parts in PNM, then in PF we can write
```julia
const PTDFPowerFlowData = PowerFlowData{
    PNM.DC_PTDF_Matrix,
    PNM.DC_ABA_Matrix_Factorized
}
```
More readable, and less likely to break.