### PR TITLE
Automatically correct units base

### DIFF
--- a/src/Ybus.jl
+++ b/src/Ybus.jl
@@ -786,6 +786,11 @@ function Ybus(
     include_constant_impedance_loads = true,
     subnetwork_algorithm = iterative_union_find,
 )
+    units_base = PSY.get_units_base(sys)
+    if units_base != "SYSTEM_BASE"
+        @warn "Setting the system unit base from $units_base to SYSTEM_BASE for matrix construction"
+        PSY.set_units_base_system!(sys, "SYSTEM_BASE")
+    end
     ref_bus_numbers = Set{Int}()
     nr = NetworkReductionData()
     bus_reduction_map = get_bus_reduction_map(nr)

--- a/test/test_ybus.jl
+++ b/test/test_ybus.jl
@@ -76,3 +76,12 @@
         @test isapprox(Ybus3.data[i[1], i[2]], Ybus3_matpower[i[1], i[2]], atol = 1e-5)
     end
 end
+
+@testset "Test modification of units base when constructing Ybus" begin
+    sys = PSB.build_system(PSB.PSITestSystems, "c_sys5")
+    PSY.set_units_base_system!(sys, "NATURAL_UNITS")
+    ybus = @test_logs (
+        :warn,
+        r"Setting the system unit base from NATURAL_UNITS to SYSTEM_BASE for matrix construction",
+    ) match_mode = :any Ybus(sys)
+end


### PR DESCRIPTION
Automatically change units to SYSTEM_BASE when constructing the Ybus (or any matrix). This matches the behavior in PSI, where the units base is automatically converted. 

This avoids incorrect behavior when a system with units base of NATURAL_UNITS is used to construct the PTDF and then used for a Simulation. In this case, the user does not modify the system during the modeling, but the references in the PTDF still do not match the system used in the Simulation. 

closes https://github.com/NREL-Sienna/PowerNetworkMatrices.jl/issues/237