### PR TITLE
suppress BLAS backend info message during precompilation

### DIFF
--- a/src/PowerNetworkMatrices.jl
+++ b/src/PowerNetworkMatrices.jl
@@ -120,21 +120,17 @@ function _pardiso_single_LODF! end
 function _create_apple_accelerate_factorization end
 
 function __init__()
-    # Suggest optimal BLAS backend.
-    if ccall(:jl_generating_output, Cint, ()) == 1
-        return
-    end
     blas_config = lowercase(string(LinearAlgebra.BLAS.get_config()))
     if Sys.iswindows() && !contains(blas_config, "mkl")
-        @info """For faster dense matrix operations, consider using MKL:
-                   pkg> add MKL
-                   using MKL  # before any matrix operations
-                 Sparse factorization still uses KLU (recommended)."""
+        @debug """For faster dense matrix operations, consider using MKL:
+                    pkg> add MKL
+                    using MKL  # before any matrix operations
+                  Sparse factorization still uses KLU (recommended)."""
     elseif Sys.isapple() && !contains(blas_config, "accelerate")
-        @info """For faster dense matrix operations, consider using AppleAccelerate:
-                   pkg> add AppleAccelerate
-                   using AppleAccelerate  # before any matrix operations
-                 Sparse factorization still uses KLU (recommended)."""
+        @debug """For faster dense matrix operations, consider using AppleAccelerate:
+                    pkg> add AppleAccelerate
+                    using AppleAccelerate  # before any matrix operations
+                  Sparse factorization still uses KLU (recommended)."""
     end
 end
 


### PR DESCRIPTION
As-is, if you have multiple dependencies that use PNM, then you get one message per dependency. This change makes it so you only get one, when you run `using PowerNetworkMatrices` for the first time.