### PR TITLE
Mb/add constructors

### DIFF
--- a/src/BA_ABA_matrices.jl
+++ b/src/BA_ABA_matrices.jl
@@ -260,7 +260,7 @@ for DC power flow analysis and power system sensitivity studies. Network reducti
 via the computed Ybus matrix.
 
 # Arguments
-- `ybus::Ybus: The power system Ybus matrix from which to construct the ABA matrix
+- `ybus::Ybus`: The power system Ybus matrix from which to construct the ABA matrix
 
 # Keyword Arguments
 - `factorize::Bool = false`:
@@ -273,12 +273,11 @@ via the computed Ybus matrix.
   - Optional KLU factorization for efficient solving
 
 # Mathematical Process
-1. **Ybus Construction**: Creates admittance matrix from system data
-2. **Incidence Matrix**: Computes bus-branch incidence matrix A
-3. **BA Matrix**: Forms branch susceptance weighted incidence matrix
-4. **ABA Computation**: Calculates A^T * B * A (bus susceptance matrix)
-5. **Reference Bus Removal**: Excludes reference buses for invertibility
-6. **Optional Factorization**: Performs KLU decomposition if requested
+1. **Incidence Matrix**: Computes bus-branch incidence matrix A (from Ybus matrix)
+2. **BA Matrix**: Forms branch susceptance weighted incidence matrix
+3. **ABA Computation**: Calculates A^T * B * A (bus susceptance matrix)
+4. **Reference Bus Removal**: Excludes reference buses for invertibility
+5. **Optional Factorization**: Performs KLU decomposition if requested
 
 # Notes
 - Reference buses are automatically detected and excluded from the final matrix

--- a/src/ptdf_calculations.jl
+++ b/src/ptdf_calculations.jl
@@ -290,7 +290,7 @@ for PTDF analysis starting from system data.
 # Mathematical Foundation
 The PTDF matrix is computed as:
 ```
-PTDF = A^T × (A^T × B × A)^(-1) × A^T × B
+PTDF = (A^T × B × A)^(-1) × A^T × B
 ```
 where A is the incidence matrix and B is the susceptance matrix.
 
@@ -332,13 +332,6 @@ direct control over the underlying matrix computations.
         Linear solver algorithm for matrix computations. Options: "KLU", "Dense", "MKLPardiso"
 - `tol::Float64 = eps()`:
         Sparsification tolerance for dropping small matrix elements to reduce memory usage
-- `network_reductions::Vector{NetworkReduction} = NetworkReduction[]`:
-        Vector of network reduction algorithms to apply before matrix construction
-- `include_constant_impedance_loads::Bool=true`:
-        Whether to include constant impedance loads as shunt admittances in the network model
-- `subnetwork_algorithm=iterative_union_find`:
-        Algorithm used for identifying electrical islands and connected components
-- Additional keyword arguments are passed to the underlying matrix constructors
 
 # Returns
 - `PTDF`: The constructed PTDF matrix structure containing:
@@ -347,12 +340,11 @@ direct control over the underlying matrix computations.
   - Sparsification tolerance and computational metadata
 
 # Construction Process
-1. **Ybus Construction**: Creates system admittance matrix with specified reductions
-2. **Incidence Matrix**: Builds bus-branch connectivity matrix A
-3. **BA Matrix**: Computes branch susceptance weighted incidence matrix
-4. **PTDF Computation**: Calculates power transfer distribution factors using A^T × B^(-1) × A
-5. **Distributed Slack**: Applies distributed slack correction if specified
-6. **Sparsification**: Removes small elements based on tolerance threshold
+1. **Incidence Matrix**: Builds bus-branch connectivity matrix A (from Ybus matrix)
+2. **BA Matrix**: Computes branch susceptance weighted incidence matrix
+3. **PTDF Computation**: Calculates power transfer distribution factors using A^T × B^(-1) × A
+4. **Distributed Slack**: Applies distributed slack correction if specified
+5. **Sparsification**: Removes small elements based on tolerance threshold
 
 # Distributed Slack Configuration
 - **Single Slack**: Empty `dist_slack` dictionary uses conventional single slack bus
@@ -368,7 +360,7 @@ direct control over the underlying matrix computations.
 # Mathematical Foundation
 The PTDF matrix is computed as:
 ```
-PTDF = A^T × (A^T × B × A)^(-1) × A^T × B
+PTDF = (A^T × B × A)^(-1) × A^T × B
 ```
 where A is the incidence matrix and B is the susceptance matrix.
 

--- a/src/virtual_ptdf_calculations.jl
+++ b/src/virtual_ptdf_calculations.jl
@@ -88,17 +88,17 @@ struct with an empty cache.
         PSY system for which the matrix is constructed
 
 # Keyword Arguments
-- `dist_slack::Vector{Float64} = Float64[]`:
-        Vector of weights to be used as distributed slack bus.
-        The distributed slack vector has to be the same length as the number of buses.
+- `dist_slack::Dict{Int, Float64} = Dict{Int, Float64}()`:
+        Dictionary of weights to be used as distributed slack bus.
+        The distributed slack dictionary must have the same number of entries as the number of buses.
 - `linear_solver::String = "KLU"`:
         Linear solver to use for factorization. Options: "KLU", "AppleAccelerate"
 - `tol::Float64 = eps()`:
         Tolerance related to sparsification and values to drop.
 - `max_cache_size::Int`:
         max cache size in MiB (initialized as MAX_CACHE_SIZE_MiB).
-- `persistent_lines::Vector{String}`:
-        line to be evaluated as soon as the VirtualPTDF is created (initialized as empty vector of strings).
+- `persistent_arcs::Vector{Tuple{Int, Int}} = Vector{Tuple{Int, Int}}()`:
+        arcs to be evaluated as soon as the VirtualPTDF is created (initialized as empty vector of tuples).
 - `network_reduction::NetworkReduction`:
         Structure containing the details of the network reduction applied when computing the matrix
 - `kwargs...`:
@@ -132,28 +132,24 @@ end
 
 """
 Builds the Virtual PTDF matrix from a Ybus matrix. This constructor is more efficient when the prerequisite Ybus
-matix is already available and provides direct control over the underlying matrix computations (including network reductions).  
+matrix is already available and provides direct control over the underlying matrix computations (including network reductions).  
 The return is a VirtualPTDF struct with an empty cache. 
 
 # Arguments
 - `ybus::Ybus`: Ybus matrix from which the matrix is constructed
 
 # Keyword Arguments
-- `dist_slack::Vector{Float64} = Float64[]`:
-        Vector of weights to be used as distributed slack bus.
-        The distributed slack vector has to be the same length as the number of buses.
+- `dist_slack::Dict{Int, Float64} = Dict{Int, Float64}()`:
+        Dictionary of weights to be used as distributed slack bus.
+        The distributed slack dictionary must have the same number of entries as the number of buses.
 - `linear_solver::String = "KLU"`:
         Linear solver to use for factorization. Options: "KLU", "AppleAccelerate"
 - `tol::Float64 = eps()`:
         Tolerance related to sparsification and values to drop.
 - `max_cache_size::Int`:
         max cache size in MiB (initialized as MAX_CACHE_SIZE_MiB).
-- `persistent_lines::Vector{String}`:
-        line to be evaluated as soon as the VirtualPTDF is created (initialized as empty vector of strings).
-- `network_reduction::NetworkReduction`:
-        Structure containing the details of the network reduction applied when computing the matrix
-- `kwargs...`:
-        other keyword arguments used by VirtualPTDF
+- `persistent_arcs::Vector{Tuple{Int, Int}} = Vector{Tuple{Int, Int}}()`:
+        arcs to be evaluated as soon as the VirtualPTDF is created (initialized as empty vector of tuples).
 """
 function VirtualPTDF(
     ybus::Ybus;

--- a/src/virtual_ptdf_calculations.jl
+++ b/src/virtual_ptdf_calculations.jl
@@ -120,14 +120,58 @@ function VirtualPTDF(
         network_reductions = network_reductions,
         kwargs...,
     )
-    ref_bus_positions = get_ref_bus_position(Ymatrix)
-    A = IncidenceMatrix(Ymatrix)
+    VirtualPTDF(
+        Ymatrix;
+        dist_slack = dist_slack,
+        linear_solver = linear_solver,
+        tol = tol,
+        max_cache_size = max_cache_size,
+        persistent_arcs = persistent_arcs,
+    )
+end
+
+"""
+Builds the Virtual PTDF matrix from a Ybus matrix. This constructor is more efficient when the prerequisite Ybus
+matix is already available and provides direct control over the underlying matrix computations (including network reductions).  
+The return is a VirtualPTDF struct with an empty cache. 
+
+# Arguments
+- `ybus::Ybus`: Ybus matrix from which the matrix is constructed
+
+# Keyword Arguments
+- `dist_slack::Vector{Float64} = Float64[]`:
+        Vector of weights to be used as distributed slack bus.
+        The distributed slack vector has to be the same length as the number of buses.
+- `linear_solver::String = "KLU"`:
+        Linear solver to use for factorization. Options: "KLU", "AppleAccelerate"
+- `tol::Float64 = eps()`:
+        Tolerance related to sparsification and values to drop.
+- `max_cache_size::Int`:
+        max cache size in MiB (initialized as MAX_CACHE_SIZE_MiB).
+- `persistent_lines::Vector{String}`:
+        line to be evaluated as soon as the VirtualPTDF is created (initialized as empty vector of strings).
+- `network_reduction::NetworkReduction`:
+        Structure containing the details of the network reduction applied when computing the matrix
+- `kwargs...`:
+        other keyword arguments used by VirtualPTDF
+"""
+function VirtualPTDF(
+    ybus::Ybus;
+    dist_slack::Dict{Int, Float64} = Dict{Int, Float64}(),
+    linear_solver::String = "KLU",
+    tol::Float64 = eps(),
+    max_cache_size::Int = MAX_CACHE_SIZE_MiB,
+    persistent_arcs::Vector{Tuple{Int, Int}} = Vector{Tuple{Int, Int}}(),
+)
+    validate_linear_solver(linear_solver)
+    ref_bus_positions = get_ref_bus_position(ybus)
+    A = IncidenceMatrix(ybus)
     if !(isempty(dist_slack))
         dist_slack_vector = redistribute_dist_slack(dist_slack, A, A.network_reduction_data)
     else
         dist_slack_vector = Float64[]
     end
-    BA = BA_Matrix(Ymatrix)
+    BA = BA_Matrix(ybus)
     ABA = calculate_ABA_matrix(A.data, BA.data, Set(ref_bus_positions))
     bus_ax = get_bus_axis(A)
     axes = A.axes
@@ -189,7 +233,7 @@ function VirtualPTDF(
         empty_cache,
         subnetwork_axes,
         Ref(tol),
-        Ymatrix.network_reduction_data,
+        ybus.network_reduction_data,
         work_ba_col,
     )
 end

--- a/test/load_tests.jl
+++ b/test/load_tests.jl
@@ -1,0 +1,32 @@
+# copied from InfrastructureSystems.jl test/load_tests.jl
+using Revise
+
+"""
+    recursive_includet(filename)
+
+Load tests for interactive use with `ReTest.jl`. Usage:
+
+```julia
+using TestEnv
+TestEnv.activate()
+include("test/load_tests.jl")
+using .PowerNetworkMatricesTests
+run_tests()
+```
+
+See the InfrastructureSystems.jl documentation page
+["Running Tests"](https://nrel-sienna.github.io/InfrastructureSystems.jl/stable/dev_guide/tests/)
+for more details.
+
+Copied from https://juliatesting.github.io/ReTest.jl/stable/#Working-with-Revise
+"""
+function recursive_includet(filename)
+    already_included = copy(Revise.included_files)
+    includet(filename)
+    newly_included = setdiff(Revise.included_files, already_included)
+    for (mod, file) in newly_included
+        Revise.track(mod, file)
+    end
+end
+
+recursive_includet("PowerNetworkMatricesTests.jl")


### PR DESCRIPTION
We commonly build two matrices back to back to set up the data for a power flow. These constructors will prevent having to repeat the Ybus building and network reduction logic for this use case. 