### PR TITLE
Ward fixes

### DIFF
--- a/src/Ybus.jl
+++ b/src/Ybus.jl
@@ -1910,35 +1910,57 @@ function get_reduction(
     return get_reduction(A, sys, reduction)
 end
 
+"""
+    _validate_study_buses(ybus::Ybus, study_buses::Vector{Int}) -> Union{Int, Nothing}
+
+Validate that Ward reduction study buses are compatible with the network islands.
+
+Checks that all study buses exist in the reduced/unreduced bus maps, that they lie in a
+single synchronously connected subnetwork, and that any partially reduced subnetwork
+includes its slack bus. Returns the reference-bus key of the matching subnetwork when
+validation succeeds.
+
+# Errors
+- Throws `IS.DataFormatError` if any study bus is not present in the system.
+- Throws `IS.DataFormatError` if study buses span multiple subnetworks.
+- Throws `IS.DataFormatError` if a partially reduced subnetwork excludes its slack bus.
+"""
 function _validate_study_buses(
     ybus::Ybus,
     study_buses::Vector{Int},
 )
     nrd = get_network_reduction_data(ybus)
-    valid_bus_numbers =
-        union(Set(keys(nrd.bus_reduction_map)), Set(keys(nrd.reverse_bus_search_map)))
-    for b in study_buses
-        b ∉ valid_bus_numbers &&
-            throw(IS.DataFormatError("Study bus $b not found in system"))
+    valid_bus_numbers = union(
+        Set(keys(nrd.bus_reduction_map)),
+        Set(keys(nrd.reverse_bus_search_map)),
+    )
+
+    for bus_number in study_buses
+        bus_number ∉ valid_bus_numbers &&
+            throw(IS.DataFormatError("Study bus $bus_number not found in system"))
     end
+
+    study_bus_set = Set(study_buses)
     slack_bus_numbers = get_ref_bus(ybus)
-    subnetwork_axes = ybus.subnetwork_axes
-    for axes in values(subnetwork_axes)
-        subnetwork_bus_ax = axes[1]
-        all_in = all(x -> x in Set(subnetwork_bus_ax), study_buses)
-        none_in = all(x -> !(x in Set(subnetwork_bus_ax)), study_buses)
-        if Set(subnetwork_bus_ax) == Set(study_buses)
-            @warn "The study buses comprise an entire island; ward reduction will not modify this island and other islands will be eliminated"
-        end
-        if !(all_in || none_in)
+
+    for (ref_bus_key, axes) in ybus.subnetwork_axes
+        subnetwork_bus_set = Set(axes[1])
+        all_in_subnetwork = issubset(study_bus_set, subnetwork_bus_set)
+        no_study_buses_in_subnetwork = isempty(intersect(study_bus_set, subnetwork_bus_set))
+        if !(all_in_subnetwork || no_study_buses_in_subnetwork)
             throw(
                 IS.DataFormatError(
                     "All study_buses must occur in a single synchronously connected system.",
                 ),
             )
         end
+
+        if !all_in_subnetwork
+            continue
+        end
+
         for sb in slack_bus_numbers
-            if sb in subnetwork_bus_ax && sb ∉ study_buses && !(none_in)
+            if sb in subnetwork_bus_set && sb ∉ study_bus_set
                 throw(
                     IS.DataFormatError(
                         "Slack bus $sb must be included in the study buses for an area that is partially reduced",
@@ -1946,9 +1968,11 @@ function _validate_study_buses(
                 )
             end
         end
-    end
 
-    return
+        return ref_bus_key
+    end
+    error("Unable to identify subnetwork for provided study buses")
+    return nothing
 end
 
 function get_reduction(
@@ -1957,13 +1981,15 @@ function get_reduction(
     reduction::WardReduction,
 )
     study_buses = get_study_buses(reduction)
-    _validate_study_buses(ybus, study_buses)
+    ref_bus_key = _validate_study_buses(ybus, study_buses)
+    subnetwork_bus_axis = ybus.subnetwork_axes[ref_bus_key][1]
     bus_lookup = get_bus_lookup(ybus)
     bus_axis = get_bus_axis(ybus)
     A = IncidenceMatrix(ybus)
     arc_axis = get_arc_axis(A)
     boundary_buses = Set{Int}()
     removed_arcs = Set{Tuple{Int, Int}}()
+    removed_buses = setdiff(Set(bus_axis), Set(subnetwork_bus_axis))
     removed_arc_to_surviving_bus = Dict{Tuple{Int, Int}, Int}()
     for arc in arc_axis
         #Determine boundary buses:
@@ -1986,6 +2012,15 @@ function get_reduction(
         push!(set, removed_arc)
     end
 
+    if Set(subnetwork_bus_axis) == Set(study_buses)
+        @error "The study buses comprise an entire island; ward reduction will not modify this island and other islands will be eliminated"
+        return NetworkReductionData(;
+            removed_arcs = removed_arcs,
+            removed_buses = removed_buses,
+            reductions = ReductionContainer(; ward_reduction = reduction),
+        )
+    end
+
     bus_reduction_map,
     reverse_bus_search_map,
     added_arc_impedance_map,
@@ -1998,6 +2033,7 @@ function get_reduction(
             boundary_buses,
             Set(get_ref_bus(ybus)),
             study_buses,
+            subnetwork_bus_axis,
         )
 
     for arc_tuple in keys(added_arc_impedance_map)
@@ -2006,11 +2042,11 @@ function get_reduction(
                     Indexing into PTDF/LODF with branch names may give unexpected results for arc $arc_tuple"
         end
     end
-
     return NetworkReductionData(;
         bus_reduction_map = bus_reduction_map,
         reverse_bus_search_map = reverse_bus_search_map,
         removed_arcs = removed_arcs,
+        removed_buses = removed_buses,
         added_arc_impedance_map = added_arc_impedance_map,
         added_admittance_map = added_admittance_map,
         removed_arc_to_surviving_bus = removed_arc_to_surviving_bus,

--- a/src/Ybus.jl
+++ b/src/Ybus.jl
@@ -1991,17 +1991,18 @@ function get_reduction(
     removed_arcs = Set{Tuple{Int, Int}}()
     removed_buses = setdiff(Set(bus_axis), Set(subnetwork_bus_axis))
     removed_arc_to_surviving_bus = Dict{Tuple{Int, Int}, Int}()
+    study_bus_set = Set(study_buses)
     for arc in arc_axis
         #Determine boundary buses:
-        if (arc[1] ∈ study_buses) && (arc[2] ∉ study_buses)
+        if (arc[1] ∈ study_bus_set) && (arc[2] ∉ study_bus_set)
             push!(boundary_buses, arc[1])
             removed_arc_to_surviving_bus[arc] = arc[1]
-        elseif (arc[1] ∉ study_buses) && (arc[2] ∈ study_buses)
+        elseif (arc[1] ∉ study_bus_set) && (arc[2] ∈ study_bus_set)
             push!(boundary_buses, arc[2])
             removed_arc_to_surviving_bus[arc] = arc[2]
         end
         #Determine arcs outside of study area
-        if !(arc[1] ∈ study_buses && arc[2] ∈ study_buses)
+        if !(arc[1] ∈ study_bus_set && arc[2] ∈ study_bus_set)
             push!(removed_arcs, arc)
         end
     end

--- a/src/Ybus.jl
+++ b/src/Ybus.jl
@@ -1413,20 +1413,27 @@ function _make_subnetwork_axes(
 )
     subnetwork_axes = deepcopy(ybus.subnetwork_axes)
     arc_subnetwork_axis = deepcopy(ybus.arc_subnetwork_axis)
-    for (k, values) in subnetwork_axes
+    for k in keys(subnetwork_axes)
         if k in bus_numbers_to_remove
-            @warn "Reference bus removed during reduction; assigning arbitrary reference bus."
             axis_1, axis_2 = pop!(subnetwork_axes, k)
             new_ref_bus = pop!(axis_1)
             pop!(axis_2)
             subnetwork_axes[new_ref_bus] = (axis_1, axis_2)
             # If a reference bus key is reduced, change the arc subnetwork axis key as well:
             arc_subnetwork_axis[new_ref_bus] = pop!(arc_subnetwork_axis, k)
+            @warn "Original reference bus $k removed during reduction; assigning arbitrary reference bus to be $new_ref_bus."
         end
     end
+    empty_subnetwork_keys = Set{Int}()
     for (k, values) in subnetwork_axes
         new_values = setdiff(values[1], bus_numbers_to_remove)
         subnetwork_axes[k] = (new_values, new_values)
+        isempty(new_values) && push!(empty_subnetwork_keys, k)
+    end
+    for k in empty_subnetwork_keys
+        @warn "Subnetwork with reference bus $k has no remaining buses after reduction and will be removed from the Ybus."
+        delete!(subnetwork_axes, k)
+        delete!(arc_subnetwork_axis, k)
     end
     for (k, values) in arc_subnetwork_axis
         arc_subnetwork_axis[k] = union(setdiff(values, arcs_to_remove), arcs_to_add)

--- a/src/ward_reduction.jl
+++ b/src/ward_reduction.jl
@@ -61,24 +61,23 @@ function get_ward_reduction(
         @error "no boundary buses found; cannot make bus_reduction_map based on impedance based criteria. mapping all external buses to the first reference bus ($first_ref_study_bus)"
         bus_reduction_map_index[first_ref_study_bus] = Set(external_buses)
     else
-        # Optimized: Only compute Z rows for external buses instead of full Z matrix
-        # This reduces complexity from O(n³) to O(n_external * n²)
         K = klu(subnetwork_data)
         boundary_bus_indices = [subnetwork_bus_lookup[x] for x in boundary_buses]
         boundary_bus_numbers = collect(boundary_buses)
+        n_boundary = length(boundary_buses)
         e = zeros(ComplexF64, n_buses)
+        Z_boundary_cols = Matrix{ComplexF64}(undef, n_buses, n_boundary)
+        # Solve one column of Z per boundary bus
+        for (j, b_idx) in enumerate(boundary_bus_indices)
+            fill!(e, zero(ComplexF64))
+            e[b_idx] = one(ComplexF64)
+            Z_boundary_cols[:, j] = K \ e
+        end
 
         for b in external_buses
             row_index = subnetwork_bus_lookup[b]
-            # Compute only the row we need: Z[row_index, :] = e_row^T * Y^(-1)
-            # This is equivalent to solving Y^T * z = e_row, but since Y is symmetric, Y * z = e_row
-            fill!(e, zero(ComplexF64))
-            e[row_index] = one(ComplexF64)
-            Z_row = K \ e  # Single row solve instead of full inverse
-
-            Z_row_boundary = abs.(Z_row[boundary_bus_indices])
-            closest_boundary_bus = boundary_bus_numbers[argmin(Z_row_boundary)]
-            push!(bus_reduction_map_index[closest_boundary_bus], b)
+            closest_j = argmin(abs2.(view(Z_boundary_cols, row_index, :)))
+            push!(bus_reduction_map_index[boundary_bus_numbers[closest_j]], b)
         end
     end
     reverse_bus_search_map =
@@ -96,7 +95,6 @@ function get_ward_reduction(
         external_bus_indices,
         boundary_bus_indices,
     ]
-
 
     # Eq. (2.16) from  https://core.ac.uk/download/pdf/79564835.pdf
     y_eq =

--- a/src/ward_reduction.jl
+++ b/src/ward_reduction.jl
@@ -47,8 +47,6 @@ function get_ward_reduction(
     subnetwork_bus_indices = [bus_lookup[x] for x in all_buses]
     subnetwork_bus_lookup = Dict(bus => ix for (ix, bus) in enumerate(all_buses))
     subnetwork_data = data[subnetwork_bus_indices, subnetwork_bus_indices]
-    println(typeof(data))
-    println(typeof(subnetwork_data))
     boundary_buses = collect(intersect(boundary_buses, Set(all_buses)))
 
     external_buses = setdiff(all_buses, study_buses)

--- a/src/ward_reduction.jl
+++ b/src/ward_reduction.jl
@@ -11,7 +11,7 @@ end
 get_study_buses(nr::WardReduction) = nr.study_buses
 
 """
-    get_ward_reduction(data, bus_lookup, bus_axis, arc_axis, boundary_buses, ref_bus_numbers, study_buses)
+    get_ward_reduction(data, bus_lookup, bus_axis, arc_axis, boundary_buses, ref_bus_numbers, study_buses, subnetwork_bus_axis)
 
 Perform Ward reduction to create an equivalent network representation.
 
@@ -27,6 +27,7 @@ buses based on impedance criteria, and equivalent admittances are computed.
 - `boundary_buses::Set{Int}`: Set of boundary bus numbers between study and external areas
 - `ref_bus_numbers::Set{Int}`: Set of reference bus numbers
 - `study_buses::Vector{Int}`: Vector of study bus numbers to retain
+- `subnetwork_bus_axis::Vector{Int}`: Bus numbers in the selected subnetwork to reduce
 
 # Returns
 - `Tuple`: Contains bus reduction map, reverse bus search map, added branch map, and added admittance map
@@ -39,13 +40,19 @@ function get_ward_reduction(
     boundary_buses::Set{Int},
     ref_bus_numbers::Set{Int},
     study_buses::Vector{Int},
+    subnetwork_bus_axis::Vector{Int},
 )
-    all_buses = bus_axis
+    # Restrict Ward operations to the study subnetwork.
+    all_buses = subnetwork_bus_axis
+    subnetwork_bus_indices = [bus_lookup[x] for x in all_buses]
+    subnetwork_bus_lookup = Dict(bus => ix for (ix, bus) in enumerate(all_buses))
+    subnetwork_data = data[subnetwork_bus_indices, subnetwork_bus_indices]
+    println(typeof(data))
+    println(typeof(subnetwork_data))
+    boundary_buses = collect(intersect(boundary_buses, Set(all_buses)))
+
     external_buses = setdiff(all_buses, study_buses)
-    boundary_buses = collect(boundary_buses)
-    n_external = length(external_buses)
-    n_boundary = length(boundary_buses)
-    n_buses = length(bus_axis)
+    n_buses = length(all_buses)
 
     bus_reduction_map_index = Dict{Int, Set{Int}}(k => Set{Int}() for k in study_buses)
 
@@ -58,13 +65,13 @@ function get_ward_reduction(
     else
         # Optimized: Only compute Z rows for external buses instead of full Z matrix
         # This reduces complexity from O(n³) to O(n_external * n²)
-        K = klu(data; allowsingular = true)
-        boundary_bus_indices = [bus_lookup[x] for x in boundary_buses]
+        K = klu(subnetwork_data)
+        boundary_bus_indices = [subnetwork_bus_lookup[x] for x in boundary_buses]
         boundary_bus_numbers = collect(boundary_buses)
         e = zeros(ComplexF64, n_buses)
 
         for b in external_buses
-            row_index = bus_lookup[b]
+            row_index = subnetwork_bus_lookup[b]
             # Compute only the row we need: Z[row_index, :] = e_row^T * Y^(-1)
             # This is equivalent to solving Y^T * z = e_row, but since Y is symmetric, Y * z = e_row
             fill!(e, zero(ComplexF64))
@@ -80,28 +87,22 @@ function get_ward_reduction(
         _make_reverse_bus_search_map(bus_reduction_map_index, length(all_buses))
 
     #Populate matrices for computing external equivalent
-    y_ee = SparseArrays.spzeros(YBUS_ELTYPE, n_external, n_external)
-    for (ix, i) in enumerate(external_buses)
-        for (jx, j) in enumerate(external_buses)
-            y_ee[ix, jx] = data[bus_lookup[i], bus_lookup[j]]
-        end
-    end
-    y_be = SparseArrays.spzeros(YBUS_ELTYPE, n_boundary, n_external)
-    for (ix, i) in enumerate(boundary_buses)
-        for (jx, j) in enumerate(external_buses)
-            y_be[ix, jx] = data[bus_lookup[i], bus_lookup[j]]
-        end
-    end
-    y_eb = SparseArrays.spzeros(YBUS_ELTYPE, n_external, n_boundary)
-    for (ix, i) in enumerate(external_buses)
-        for (jx, j) in enumerate(boundary_buses)
-            y_eb[ix, jx] = data[bus_lookup[i], bus_lookup[j]]
-        end
-    end
+    external_bus_indices = [subnetwork_bus_lookup[x] for x in external_buses]
+    boundary_bus_indices = [subnetwork_bus_lookup[x] for x in boundary_buses]
+    y_ee = subnetwork_data[external_bus_indices, external_bus_indices]
+    y_be = subnetwork_data[
+        boundary_bus_indices,
+        external_bus_indices,
+    ]
+    y_eb = subnetwork_data[
+        external_bus_indices,
+        boundary_bus_indices,
+    ]
+
 
     # Eq. (2.16) from  https://core.ac.uk/download/pdf/79564835.pdf
     y_eq =
-        y_be * KLU.solve!(klu(y_ee; allowsingular = true), Matrix{Complex{Float64}}(y_eb))
+        y_be * KLU.solve!(klu(y_ee), Matrix{Complex{Float64}}(y_eb))
     #Loop upper diagonal of Yeq
     for ix in 1:length(boundary_buses)
         for jx in ix:length(boundary_buses)

--- a/src/ward_reduction.jl
+++ b/src/ward_reduction.jl
@@ -58,7 +58,7 @@ function get_ward_reduction(
     else
         # Optimized: Only compute Z rows for external buses instead of full Z matrix
         # This reduces complexity from O(n³) to O(n_external * n²)
-        K = klu(data)
+        K = klu(data; allowsingular = true)
         boundary_bus_indices = [bus_lookup[x] for x in boundary_buses]
         boundary_bus_numbers = collect(boundary_buses)
         e = zeros(ComplexF64, n_buses)
@@ -100,7 +100,8 @@ function get_ward_reduction(
     end
 
     # Eq. (2.16) from  https://core.ac.uk/download/pdf/79564835.pdf
-    y_eq = y_be * KLU.solve!(klu(y_ee), Matrix{Complex{Float64}}(y_eb))
+    y_eq =
+        y_be * KLU.solve!(klu(y_ee; allowsingular = true), Matrix{Complex{Float64}}(y_eb))
     #Loop upper diagonal of Yeq
     for ix in 1:length(boundary_buses)
         for jx in ix:length(boundary_buses)

--- a/test/test_ward_reduction.jl
+++ b/test/test_ward_reduction.jl
@@ -178,3 +178,37 @@ end
         Ybus(sys; network_reductions = NetworkReduction[WardReduction([2, 3, 4])]),
     )
 end
+
+@testset "WardReduction with isolated buses" begin
+    sys = PSB.build_system(PSB.PSITestSystems, "c_sys5")
+    sys_with_isolated = deepcopy(sys)
+    bus6 = ACBus(;
+        number = 6,
+        name = "Bus 6",
+        available = true,
+        bustype = ACBusTypes.REF,
+        angle = 0.0,
+        magnitude = 1.0,
+        voltage_limits = (min = 0.9, max = 1.05),
+        base_voltage = 69.0,
+    )
+    add_component!(sys_with_isolated, bus6)
+    bus5 = get_component(ACBus, sys_with_isolated, "nodeD")
+    hvdc1 = TwoTerminalHVDCLine(;
+        name = "Line18",
+        available = true,
+        active_power_flow = 0.0,
+        arc = Arc(; from = bus5, to = bus6),
+        active_power_limits_from = (min = -100.0, max = 100.0),
+        active_power_limits_to = (min = -100.0, max = 100.0),
+        reactive_power_limits_from = (min = -100.0, max = 100.0),
+        reactive_power_limits_to = (min = -100.0, max = 100.0),
+    )
+    add_component!(sys_with_isolated, hvdc1)
+    ybus = Ybus(sys; network_reductions = NetworkReduction[WardReduction([1, 2, 3, 4])])
+    ybus_with_isolated = Ybus(
+        sys_with_isolated;
+        network_reductions = NetworkReduction[WardReduction([1, 2, 3, 4])],
+    )
+    @test ybus.data == ybus_with_isolated.data
+end

--- a/test/test_ward_reduction.jl
+++ b/test/test_ward_reduction.jl
@@ -155,7 +155,7 @@ end
     @test length(wr.added_admittance_map) == 1
 
     wr =
-        @test_logs (:error, r"no boundary buses found") match_mode = :any get_network_reduction_data(
+        @test_logs (:error, r"The study buses comprise an entire island") match_mode = :any get_network_reduction_data(
             Ybus(sys; network_reductions = NetworkReduction[WardReduction([15, 16, 17])]),
         )
     @test isa(wr, NetworkReductionData)

--- a/test/test_ward_reduction.jl
+++ b/test/test_ward_reduction.jl
@@ -211,4 +211,6 @@ end
         network_reductions = NetworkReduction[WardReduction([1, 2, 3, 4])],
     )
     @test ybus.data == ybus_with_isolated.data
+    # Building PTDF tests handling of subnetwork_axes when an entire subnetwork is eliminated during reduction:
+    @test isa(PTDF(ybus_with_isolated), PTDF)
 end


### PR DESCRIPTION
Fixes:
- Ward fails with singular value exception in klu when an HVDC connects to a single isolated bus.
- Bug in the handling of subnetwork axes when an entire subnetwork is eliminated via Ward. 

These fixes are needed for running Ward on WECC due to the representation of the hvdc interties to the EI. 