### PR TITLE
avoid deep copy if the SolveCaches

### DIFF
--- a/src/AccelerateWrapper/aa_cache.jl
+++ b/src/AccelerateWrapper/aa_cache.jl
@@ -189,6 +189,23 @@ end
 
 Base.finalize(cache::AAFactorCache) = _free_handles!(cache)
 
+# `deepcopy` is UNSAFE on this cache: `numeric`/`symbolic` are opaque libSparse
+# factorization structs holding raw factor pointers, freed by `finalizer(_free_handles!`.
+# A naive `deepcopy` bit-copies those pointers, yielding two caches that alias one
+# libSparse factor; when one copy is collected its `SparseCleanup` frees the factor
+# out from under the other — the next `solve!` reads freed memory (SIGSEGV / SIGILL
+# inside `SparseSolve`). Throw so the offending caller is identified by the backtrace;
+# the owning Virtual matrix must be shared by reference, not deepcopied.
+function Base.deepcopy_internal(::AAFactorCache, ::IdDict)
+    error(
+        "deepcopy of an AAFactorCache is unsafe and was attempted: the cache holds raw " *
+        "libSparse factor handles that deepcopy would alias by value, causing a " *
+        "double-free / use-after-free of the factorization (SIGSEGV/SIGILL in SparseSolve). " *
+        "Share the owning Virtual matrix by reference instead of deepcopying it. The " *
+        "backtrace identifies the offending call site.",
+    )
+end
+
 # Build the libSparse `SparseMatrixStructure` view that points into the
 # cache's owned arrays. Always marked `ATT_ORDINARY` — the LU path treats
 # `cache.nzval` as the full matrix with no symmetry assumed.

--- a/src/AccelerateWrapper/aa_cache.jl
+++ b/src/AccelerateWrapper/aa_cache.jl
@@ -189,13 +189,10 @@ end
 
 Base.finalize(cache::AAFactorCache) = _free_handles!(cache)
 
-# `deepcopy` is UNSAFE on this cache: `numeric`/`symbolic` are opaque libSparse
-# factorization structs holding raw factor pointers, freed by `finalizer(_free_handles!`.
-# A naive `deepcopy` bit-copies those pointers, yielding two caches that alias one
-# libSparse factor; when one copy is collected its `SparseCleanup` frees the factor
-# out from under the other — the next `solve!` reads freed memory (SIGSEGV / SIGILL
-# inside `SparseSolve`). Throw so the offending caller is identified by the backtrace;
-# the owning Virtual matrix must be shared by reference, not deepcopied.
+# `deepcopy` is unsafe: it would bit-copy the raw libSparse factor handles,
+# aliasing one factorization across two finalizer-owning caches (a
+# double-free/use-after-free). Throw so the caller shares the owning matrix by
+# reference instead; the backtrace names the offending site.
 function Base.deepcopy_internal(::AAFactorCache, ::IdDict)
     error(
         "deepcopy of an AAFactorCache is unsafe and was attempted: the cache holds raw " *

--- a/src/KLUWrapper/klu_cache.jl
+++ b/src/KLUWrapper/klu_cache.jl
@@ -512,6 +512,26 @@ end
 # stays unexported per the KLUWrapper convention).
 Base.finalize(cache::KLULinSolveCache) = _free_klu_handles!(cache)
 
+# `deepcopy` is UNSAFE on this cache: `symbolic`/`numeric` are raw `Ptr{Cvoid}`
+# handles into libklu. A naive `deepcopy` bit-copies the pointer values, yielding
+# two cache objects that alias one libklu factorization; each carries
+# `finalizer(_free_klu_handles!, …)`, so when one copy is collected its finalizer
+# frees the handle out from under the other — the next `solve!` reads freed/reused
+# memory (garbage `Numeric.n` → `KLU_INVALID`, or `SIGSEGV` inside `klu_l_solve`).
+# Throw instead, so the offending caller is identified by the backtrace. The owning
+# `Virtual{PTDF,LODF,MODF}` must be shared by reference, not deepcopied. (A future
+# deepcopy-safe path can re-factorize from the cached `colptr`/`rowval`/`nzval` into
+# an independent handle; until then, copying is rejected.)
+function Base.deepcopy_internal(::KLULinSolveCache, ::IdDict)
+    error(
+        "deepcopy of a KLULinSolveCache is unsafe and was attempted: the cache holds " *
+        "raw libklu Symbolic/Numeric pointers that deepcopy would alias by value, " *
+        "causing a double-free / use-after-free of the factorization (KLU_INVALID or " *
+        "SIGSEGV). Share the owning Virtual matrix by reference instead of deepcopying " *
+        "it. The backtrace identifies the offending call site.",
+    )
+end
+
 """
 Drop a corrupted numeric handle and rebuild it from the values cached in
 `cache.nzval`. Used by `solve_sparse!` on the `KLU_INVALID` retry path, where

--- a/src/KLUWrapper/klu_cache.jl
+++ b/src/KLUWrapper/klu_cache.jl
@@ -512,16 +512,10 @@ end
 # stays unexported per the KLUWrapper convention).
 Base.finalize(cache::KLULinSolveCache) = _free_klu_handles!(cache)
 
-# `deepcopy` is UNSAFE on this cache: `symbolic`/`numeric` are raw `Ptr{Cvoid}`
-# handles into libklu. A naive `deepcopy` bit-copies the pointer values, yielding
-# two cache objects that alias one libklu factorization; each carries
-# `finalizer(_free_klu_handles!, …)`, so when one copy is collected its finalizer
-# frees the handle out from under the other — the next `solve!` reads freed/reused
-# memory (garbage `Numeric.n` → `KLU_INVALID`, or `SIGSEGV` inside `klu_l_solve`).
-# Throw instead, so the offending caller is identified by the backtrace. The owning
-# `Virtual{PTDF,LODF,MODF}` must be shared by reference, not deepcopied. (A future
-# deepcopy-safe path can re-factorize from the cached `colptr`/`rowval`/`nzval` into
-# an independent handle; until then, copying is rejected.)
+# `deepcopy` is unsafe: it would bit-copy the raw libklu `symbolic`/`numeric`
+# pointers, aliasing one factorization across two finalizer-owning caches (a
+# double-free/use-after-free). Throw so the caller shares the owning matrix by
+# reference instead; the backtrace names the offending site.
 function Base.deepcopy_internal(::KLULinSolveCache, ::IdDict)
     error(
         "deepcopy of a KLULinSolveCache is unsafe and was attempted: the cache holds " *


### PR DESCRIPTION
This patch resolved the segfault problems in PSI with PNM caused by silent deep copy calls in the problem creation. I managed to trace the problem to Gc'd pointers from the copies. The solution is in PSI but this is a defensive block on calling deep copy con pointers 