### PR TITLE
Mb/modf irreducible patch

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "PowerNetworkMatrices"
 uuid = "bed98974-b02a-5e2f-9fe0-a103f5c450dd"
-version = "0.24.0"
+version = "0.23.0"
 authors = ["SIENNA TEAM"]
 
 [deps]

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "PowerNetworkMatrices"
 uuid = "bed98974-b02a-5e2f-9fe0-a103f5c450dd"
-version = "0.23.0"
+version = "0.24.0"
 authors = ["SIENNA TEAM"]
 
 [deps]

--- a/src/modf_reduction_consistency.jl
+++ b/src/modf_reduction_consistency.jl
@@ -51,19 +51,17 @@ function _accumulate_monitored_buses!(
     return
 end
 
-# Bus -> ZI-merge survivor map, read from an already-built `Ybus`. Reusing the caller's
-# Ybus avoids a second full network assembly just for this map.
-_zero_impedance_survivor_map(ybus::Ybus) =
-    get_reverse_bus_search_map(get_network_reduction_data(ybus))
-
 """
-    _collect_protected_buses(sys, ybus) -> Set{Int}
+    _collect_protected_buses(sys) -> Set{Int}
 
 Buses to protect so every `PSY.Outage`'s outaged and monitored components
-remain queryable as arcs after reduction. Buses are routed through `ybus`'s
-ZI-survivor map so that protecting a ZI-merged endpoint protects its survivor.
+remain queryable as arcs after reduction. Computed from `sys` alone (no `Ybus`
+needed) so the result can be folded into `irreducible_buses` *before* the base
+`Ybus` (and its auto-applied zero-impedance reduction) is built — otherwise a
+monitored/outaged branch endpoint could be merged away by ZIBR before it is
+known to need protecting.
 """
-function _collect_protected_buses(sys::PSY.System, ybus::Ybus)
+function _collect_protected_buses(sys::PSY.System)
     buses = Set{Int}()
     for outage in PSY.get_supplemental_attributes(PSY.Outage, sys)
         for component in PSY.get_associated_components(sys, outage)
@@ -71,9 +69,7 @@ function _collect_protected_buses(sys::PSY.System, ybus::Ybus)
         end
         _accumulate_monitored_buses!(buses, sys, outage)
     end
-    isempty(buses) && return Set{Int}()
-    zi_map = _zero_impedance_survivor_map(ybus)
-    return Set{Int}(get(zi_map, b, b) for b in buses)
+    return buses
 end
 
 _merge_irreducible(existing, protected::Set{Int}) =
@@ -93,15 +89,4 @@ function _augment_ward_reductions(
     protected::Set{Int},
 )
     return NetworkReduction[_augment_ward(r, protected) for r in reductions]
-end
-
-# Fold `protected` into the base Ybus's shared reduction container so radial/degree-two
-# reductions, which read the user irreducible set from it, honor them. Relies on the
-# container being read lazily by each later `build_reduced_ybus` step.
-function _inject_protected_buses!(ybus::Ybus, protected::Set{Int})
-    union!(
-        get_user_irreducible_buses(get_reductions(get_network_reduction_data(ybus))),
-        protected,
-    )
-    return
 end

--- a/src/virtual_modf_calculations.jl
+++ b/src/virtual_modf_calculations.jl
@@ -256,10 +256,13 @@ Base.setindex!(::VirtualMODF, _, ::CartesianIndex) =
 Build a VirtualMODF from a PowerSystems System. Automatically registers all
 Outage supplemental attributes found in the system.
 
-When `network_reductions` are supplied, they are adjusted to retain the buses of
-every outaged component and the components each outage declares monitored
-(`get_monitored_components`). This is mandatory: the ABA/Woodbury solve runs on the
-reduced network, so a branch in a contingency must survive reduction.
+The buses of every outaged component and the components each outage declares
+monitored (`get_monitored_components`) are automatically added to the irreducible
+set before the base `Ybus` is built, and (when `network_reductions` are supplied)
+any `WardReduction.study_buses` are augmented to match. This is mandatory: the
+ABA/Woodbury solve runs on the reduced network, so a branch in a contingency must
+survive every reduction step, including the zero-impedance reduction that is
+auto-applied during `Ybus` construction.
 
 # Arguments
 - `sys::PSY.System`: Power system to build from
@@ -301,19 +304,21 @@ function VirtualMODF(
         _reject_zibr_in_user_reductions(r)
     end
 
-    # Build the base Ybus once (zero-impedance reduction auto-applied). It supplies the
-    # ZI-survivor map for the protection set and is the starting point for the reductions.
-    Ymatrix = Ybus(sys; irreducible_buses = irreducible_buses, kwargs...)
-
     # Outage/monitored buses are auto-protected so contingency branches survive
-    # reduction. Registering an outage with previously-unseen monitored components
-    # after construction shifts this set and requires rebuilding the MODF.
-    protected_buses = _collect_protected_buses(sys, Ymatrix)
+    # reduction. Collect them from `sys` before building the base Ybus and fold
+    # them into `irreducible_buses` so the auto-applied zero-impedance reduction
+    # never merges away a monitored/outaged branch endpoint in the first place.
+    # Registering an outage with previously-unseen monitored components after
+    # construction shifts this set and requires rebuilding the MODF.
+    protected_buses = _collect_protected_buses(sys)
     applied_irreducible = union(irreducible_buses, protected_buses)
 
-    # Protect via two channels: radial/degree-two read the container's irreducible set,
-    # while Ward reads `study_buses` (augmented separately).
-    _inject_protected_buses!(Ymatrix, protected_buses)
+    # Build the base Ybus with the combined irreducible set (zero-impedance reduction
+    # auto-applied here honors it); this is the starting point for further reductions.
+    Ymatrix = Ybus(sys; irreducible_buses = applied_irreducible, kwargs...)
+
+    # radial/degree-two read the container's irreducible set (already seeded above via
+    # `Ybus`'s `irreducible_buses`), while Ward reads `study_buses` (augmented separately).
     applied_reductions = _augment_ward_reductions(network_reductions, applied_irreducible)
     for reduction in applied_reductions
         Ymatrix = build_reduced_ybus(Ymatrix, sys, reduction)

--- a/test/test_modf_reduction_consistency.jl
+++ b/test/test_modf_reduction_consistency.jl
@@ -61,7 +61,7 @@ _retained_buses(vmodf) =
         PSY.add_supplemental_attribute!(sys, line, _fixed_outage())
     end
 
-    protected = PNM._collect_protected_buses(sys, Ybus(sys))
+    protected = PNM._collect_protected_buses(sys)
     for line in outaged
         fb, tb = _arc_buses(line)
         @test fb in protected
@@ -80,7 +80,7 @@ end
         _fixed_outage(; monitored = [monitored]),
     )
 
-    protected = PNM._collect_protected_buses(sys, Ybus(sys))
+    protected = PNM._collect_protected_buses(sys)
     # Both the outaged branch and its monitored branch contribute their buses.
     for branch in (outaged, monitored)
         fb, tb = _arc_buses(branch)
@@ -100,7 +100,7 @@ end
     # Regression: Transformer3W <: ACTransmission but has no `get_arc`, so the
     # generic ACTransmission path would throw MethodError. It must route to the
     # 3WT-specific method and protect all of the transformer's buses.
-    protected = PNM._collect_protected_buses(sys, Ybus(sys))
+    protected = PNM._collect_protected_buses(sys)
     @test !isempty(protected)
     for arc in (
         PSY.get_primary_star_arc(t3w),
@@ -200,6 +200,33 @@ end
         sys;
         network_reductions = NetworkReduction[RadialReduction(), DegreeTwoReduction()],
     )
+
+    mfb, mtb = _arc_buses(monitored)
+    @test mfb in _retained_buses(vmodf)
+    @test mtb in _retained_buses(vmodf)
+    arc_lookup = PNM.get_arc_lookup(vmodf)
+    @test haskey(arc_lookup, (mfb, mtb)) || haskey(arc_lookup, (mtb, mfb))
+end
+
+@testset "VirtualMODF protects monitored branch endpoint merged by zero-impedance reduction" begin
+    # `psse_14_network_reduction_test_system` has a zero-impedance branch (104, 105);
+    # bus 105 is merged into bus 104 by the auto-applied ZeroImpedanceBranchReduction
+    # when neither bus is irreducible (see "ZeroImpedanceBranchReduction respects
+    # irreducible buses" in test_ybus_reductions.jl). The monitored branch below has
+    # bus 105 as an endpoint, so its (102, 105) arc must survive — bus 105 needs to be
+    # irreducible *before* the base Ybus (and its ZIBR pass) is built, not after.
+    sys = PSB.build_system(PSB.PSSEParsingTestSystems, "psse_14_network_reduction_test_system")
+    monitored = PSY.get_component(PSY.ACTransmission, sys, "BUS 102_102-BUS 105_105-i_1")
+    outaged = PSY.get_component(PSY.ACTransmission, sys, "BUS 107_107-BUS 108_108-i_1")
+    @test monitored !== nothing
+    @test outaged !== nothing
+
+    PSY.add_supplemental_attribute!(
+        sys,
+        outaged,
+        _fixed_outage(; monitored = [monitored]),
+    )
+    vmodf = VirtualMODF(sys)
 
     mfb, mtb = _arc_buses(monitored)
     @test mfb in _retained_buses(vmodf)


### PR DESCRIPTION
Collect the irreducible buses due to outaged/monitored branches before constructing the Ybus for the first time.  
